### PR TITLE
Temporary workaround for year check

### DIFF
--- a/src/middlewares/joi/joiBooksValidation.js
+++ b/src/middlewares/joi/joiBooksValidation.js
@@ -4,7 +4,7 @@ const addBookValidation = (req, res, next) => {
   const schema = Joi.object({
     title: Joi.string().required(),
     author: Joi.string().required(),
-    year: Joi.number().integer(),
+    year: Joi.number().integer().allow(''),
     pages: Joi.number().integer().required(),
   });
   const valid = schema.validate(req.body);


### PR DESCRIPTION
Allow empty sting as year in Creating new book. Saving null in Database, front representing correctly