### PR TITLE
Bugfix/empty resume rating

### DIFF
--- a/src/controllers/training/updateTraining.js
+++ b/src/controllers/training/updateTraining.js
@@ -19,7 +19,10 @@ const updateTraining = async (req, res) => {
         }
         return previousValue
     }, 0)
-    if (totalBooksPagesCount - totalPagesReadCount < Number(body.pages)) throw RequestError(400, 'Provided pages count exceeds number of unread pages!')
+    if (totalBooksPagesCount - totalPagesReadCount < Number(body.pages)) {
+        const pagesRemained = totalBooksPagesCount - totalPagesReadCount
+        throw RequestError(400, `Provided pages count exceeds number of unread ${pagesRemained} pages!`)
+    }
     if (totalPagesReadCount + Number(body.pages) >= totalBooksPagesCount) {
         for (const book of books) {
             const originalBook = await booksServices.getById({ bookId: book._id, owner })

--- a/src/middlewares/joi/joiBooksValidation.js
+++ b/src/middlewares/joi/joiBooksValidation.js
@@ -33,8 +33,8 @@ const updateStatesValidation = (req, res, next) => {
 
 const updateResumeValidation = (req, res, next) => {
   const schema = Joi.object({
-    rating: Joi.number().integer().greater(0).less(6),
-    resume: Joi.string(),
+    rating: Joi.number().integer().min(0).max(5),
+    resume: Joi.string().allow(''),
   });
   const valid = schema.validate(req.body);
 

--- a/src/services/booksServices.js
+++ b/src/services/booksServices.js
@@ -21,18 +21,10 @@ const updateBookStatus = async (bookId, owner, { status }) => {
 };
 
 const updateBookResume = async (bookId, owner, { resume, rating }) => {
-  if (!resume) {
-    await Book.findByIdAndUpdate({ _id: bookId, owner }, { $set: { rating } });
-  }
-  if (!rating) {
-    await Book.findByIdAndUpdate({ _id: bookId, owner }, { $set: { resume } });
-  }
-  if (rating && resume) {
-    await Book.findByIdAndUpdate(
-      { _id: bookId, owner },
-      { $set: { resume, rating } }
-    );
-  }
+  await Book.findByIdAndUpdate(
+    { _id: bookId, owner },
+    { $set: { resume, rating } }
+  );
 };
 
 const editBook = async (contactId, owner, bookData) => {


### PR DESCRIPTION
Removing check of empty rating or summary fields to clear the values, Rixing error text on exceeding total number of unread pages in training - adding number of pages